### PR TITLE
Add OCR API using AWS Lambda

### DIFF
--- a/.cursor/rules/02-dependencies-versions.mdc
+++ b/.cursor/rules/02-dependencies-versions.mdc
@@ -111,11 +111,15 @@ dependencies {
 ### 4️⃣ **운영 환경 준비** (AWS + 모니터링)
 ```gradle
 dependencies {
-    // AWS SDK v2
+    // AWS SDK v2 (Lambda 호출용)
+    implementation platform('software.amazon.awssdk:bom:2.25.62')
+    implementation 'software.amazon.awssdk:lambda'
+
+    // AWS Spring Cloud (S3, SQS 등)
     implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.2.1')
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
-    
+
     // 운영 모니터링
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
@@ -170,6 +174,10 @@ dependencies {
     // 📌 Documentation
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
     
+    // 📌 AWS SDK v2 (Lambda)
+    implementation platform('software.amazon.awssdk:bom:2.25.62')
+    implementation 'software.amazon.awssdk:lambda'
+
     // 📌 AWS Services (프로덕션용)
     implementation platform('io.awspring.cloud:spring-cloud-aws-dependencies:3.2.1')
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'

--- a/.cursor/rules/03-configuration-management.mdc
+++ b/.cursor/rules/03-configuration-management.mdc
@@ -74,6 +74,11 @@ logging:
     com.sbpb.ddobak: debug
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+
+aws:
+  region: ap-northeast-2
+  lambda:
+    function-name: your-lambda-function
 ```
 
 ### 📌 2단계: 로컬 개발 환경 (application-local.yml)
@@ -296,6 +301,7 @@ GOOGLE_CLIENT_SECRET=your_google_client_secret
 # AWS_SECRET_ACCESS_KEY=your_secret_key
 # AWS_REGION=ap-northeast-2
 # AWS_S3_BUCKET=ddobak-local-bucket
+# AWS_LAMBDA_FUNCTION=your-lambda-function
 
 # External APIs
 EXTERNAL_API_BASE_URL=https://api.external-service.com

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,17 @@ repositories {
 	mavenCentral()
 }
 
-dependencies {
-	// Spring Boot Starters
-	implementation 'org.springframework.boot:spring-boot-starter'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+    dependencies {
+        // Spring Boot Starters
+        implementation 'org.springframework.boot:spring-boot-starter'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        implementation 'org.springframework.boot:spring-boot-starter-validation'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+
+        // AWS SDK
+        implementation platform('software.amazon.awssdk:bom:2.25.62')
+        implementation 'software.amazon.awssdk:lambda'
 	
 	// JSON 처리
 	implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/src/main/java/com/sbpb/ddobak/server/config/aws/LambdaConfig.java
+++ b/src/main/java/com/sbpb/ddobak/server/config/aws/LambdaConfig.java
@@ -1,0 +1,23 @@
+package com.sbpb.ddobak.server.config.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+
+@Configuration
+public class LambdaConfig {
+
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public LambdaClient lambdaClient() {
+        return LambdaClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/controller/OcrController.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/controller/OcrController.java
@@ -1,0 +1,34 @@
+package com.sbpb.ddobak.server.domain.documentProcess.controller;
+
+import com.sbpb.ddobak.server.common.response.ApiResponse;
+import com.sbpb.ddobak.server.domain.documentProcess.dto.OcrRequest;
+import com.sbpb.ddobak.server.domain.documentProcess.service.OcrService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * OCR 요청을 처리하는 컨트롤러.
+ */
+@RestController
+@RequestMapping("/api/v1/ocr")
+@RequiredArgsConstructor
+@Slf4j
+public class OcrController {
+
+    private final OcrService ocrService;
+
+    /**
+     * OCR 분석 요청을 처리한다.
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<Object>> analyze(@Valid @RequestBody OcrRequest request) {
+        ApiResponse<Object> response = ocrService.requestOcr(request.getS3Key());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/dto/OcrRequest.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/dto/OcrRequest.java
@@ -1,0 +1,16 @@
+package com.sbpb.ddobak.server.domain.documentProcess.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * OCR 요청 시 사용되는 DTO.
+ */
+@Getter
+@NoArgsConstructor
+public class OcrRequest {
+
+    @NotBlank(message = "s3Key is required")
+    private String s3Key;
+}

--- a/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/OcrService.java
+++ b/src/main/java/com/sbpb/ddobak/server/domain/documentProcess/service/OcrService.java
@@ -1,0 +1,31 @@
+package com.sbpb.ddobak.server.domain.documentProcess.service;
+
+import com.sbpb.ddobak.server.common.response.ApiResponse;
+import com.sbpb.ddobak.server.infrastructure.aws.Lambda;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * OCR 처리를 담당하는 서비스.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class OcrService {
+
+    private final Lambda lambda;
+
+    /**
+     * 주어진 S3 경로를 Lambda로 전달하여 OCR 결과를 받아온다.
+     *
+     * @param s3Key S3 object key
+     * @return Lambda로부터 받은 ApiResponse
+     */
+    public ApiResponse<Object> requestOcr(String s3Key) {
+        log.info("Requesting OCR for key: {}", s3Key);
+        return lambda.requestLambda(s3Key);
+    }
+}

--- a/src/main/java/com/sbpb/ddobak/server/infrastructure/aws/Lambda.java
+++ b/src/main/java/com/sbpb/ddobak/server/infrastructure/aws/Lambda.java
@@ -1,0 +1,49 @@
+package com.sbpb.ddobak.server.infrastructure.aws;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sbpb.ddobak.server.common.exception.ExternalServiceException;
+import com.sbpb.ddobak.server.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+
+import java.util.Map;
+
+/**
+ * AWS Lambda 호출을 담당하는 클래스.
+ */
+@Component
+@RequiredArgsConstructor
+public class Lambda {
+
+    private final LambdaClient lambdaClient;
+    private final ObjectMapper objectMapper;
+
+    @Value("${aws.lambda.function-name}")
+    private String functionName;
+
+    /**
+     * 주어진 S3 키를 Lambda 함수로 전달하여 OCR 결과를 가져온다.
+     *
+     * @param key S3 object key
+     * @return Lambda로부터 받은 ApiResponse
+     */
+    public ApiResponse<Object> requestLambda(String key) {
+        try {
+            String payload = objectMapper.writeValueAsString(Map.of("s3Key", key));
+            InvokeRequest request = InvokeRequest.builder()
+                    .functionName(functionName)
+                    .payload(SdkBytes.fromUtf8String(payload))
+                    .build();
+
+            String responseJson = lambdaClient.invoke(request).payload().asUtf8String();
+            return objectMapper.readValue(responseJson, new TypeReference<ApiResponse<Object>>() {});
+        } catch (Exception e) {
+            throw new ExternalServiceException("Lambda", e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring:
   application:
-    name: main-server 
+    name: main-server
+
+aws:
+  region: ap-northeast-2
+  lambda:
+    function-name: your-lambda-function


### PR DESCRIPTION
## Summary
- introduce controller and service for OCR requests
- create DTO for OCR lambda call
- use existing Lambda client to request OCR function
- document AWS SDK dependency and settings in rules

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684e76baac8083268de1ad6bb6c48af1